### PR TITLE
fix accessory bag overlay obscuring tooltips

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUEventListener.java
@@ -693,7 +693,7 @@ public class NEUEventListener {
      * @param event
      */
     @SubscribeEvent
-    public void onGuiScreenDrawPost(GuiScreenEvent.DrawScreenEvent.Post event) {
+    public void onGuiScreenDrawPost(GuiScreenEvent.DrawScreenEvent.BackgroundDrawnEvent event) {
         if(!(TradeWindow.tradeWindowActive() || event.gui instanceof CustomAHGui ||
                 neu.manager.auctionManager.customAH.isRenderOverAuctionView())) {
             if(shouldRenderOverlay(event.gui) && neu.isOnSkyblock()) {


### PR DESCRIPTION
the accessory bag overlay currently obscures tooltips due to the wrong event being used. this fixes that and allows tooltips to be drawn on top of the overlay.