### PR TITLE
Fix detecting if you're in skyblock

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NotEnoughUpdates.java
@@ -1056,8 +1056,8 @@ public class NotEnoughUpdates {
 
     //Stolen from Biscut's SkyblockAddons
     public void updateSkyblockScoreboard() {
-        final Pattern SERVER_BRAND_PATTERN = Pattern.compile("(.+) <- (?:.+)");
-        final String HYPIXEL_SERVER_BRAND = "BungeeCord (Hypixel)";
+        final Pattern SERVER_BRAND_PATTERN = Pattern.compile("(?:.*)(Hypixel)(?:.*) <- (?:.+)");
+        final String HYPIXEL_SERVER_BRAND = "Hypixel";
 
         Minecraft mc = Minecraft.getMinecraft();
 


### PR DESCRIPTION
Hypixel is now sometimes sending the server brand as "Hypixel BungeeCord (1.0.0) <- vanilla", this is probably a mistake but this commit makes the regex more lenient so it will detect any string that contains hypixel and looks like bungeecord