### PR TITLE
Improved number shortening to allow for decimal places

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/commands/Commands.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/commands/Commands.java
@@ -528,10 +528,10 @@ public class Commands {
                                 EnumChatFormatting moneyPrefix = money>50*1000*1000?
                                         (money>200*1000*1000?EnumChatFormatting.GREEN:EnumChatFormatting.YELLOW):EnumChatFormatting.RED;
                                 Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(
-                                        g+"Purse: "+moneyPrefix+Utils.shortNumberFormat(purseBalance, 0) + g+" - Bank: " +
+                                        g+"Purse: "+moneyPrefix+Utils.shortNumberFormat(purseBalance) + g+" - Bank: " +
                                                 (bankBalance == -1 ? EnumChatFormatting.YELLOW+"N/A" : moneyPrefix+
-                                                        (isMe?"4.8b":Utils.shortNumberFormat(bankBalance, 0))) +
-                                                (networth > 0 ? g+" - Net: "+moneyPrefix+Utils.shortNumberFormat(networth, 0) : "")));
+                                                        (isMe?"4.8b":Utils.shortNumberFormat(bankBalance))) +
+                                                (networth > 0 ? g+" - Net: "+moneyPrefix+Utils.shortNumberFormat(networth, 2) : "")));
 
                                 overallScore += Math.min(2, money/(100f*1000*1000));
 

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/AuctionBINWarning.java
@@ -148,14 +148,14 @@ public class AuctionBINWarning extends GuiElement {
 
         String lowestPriceStr;
         if(lowestPrice > 999) {
-            lowestPriceStr = Utils.shortNumberFormat(lowestPrice, 0);
+            lowestPriceStr = Utils.shortNumberFormat(lowestPrice);
         } else {
             lowestPriceStr = ""+lowestPrice;
         }
 
         String sellingPriceStr;
         if(sellingPrice > 999) {
-            sellingPriceStr = Utils.shortNumberFormat(sellingPrice, 0);
+            sellingPriceStr = Utils.shortNumberFormat(sellingPrice);
         } else {
             sellingPriceStr = ""+sellingPrice;
         }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DamageCommas.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/DamageCommas.java
@@ -67,7 +67,7 @@ public class DamageCommas {
             int number = Integer.parseInt(numbers);
 
             if(number > 999 && NotEnoughUpdates.INSTANCE.config.misc.damageIndicatorStyle == 2) {
-                newFormatted.append(Utils.shortNumberFormat(number, 0));
+                newFormatted.append(Utils.shortNumberFormat(number, 2));
             } else {
                 newFormatted.append(NumberFormat.getIntegerInstance().format(number));
             }

--- a/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/miscfeatures/PetInfoOverlay.java
@@ -357,8 +357,8 @@ public class PetInfoOverlay extends TextOverlay {
                 roundFloat(currentPet.petLevel.currentLevelRequirement)
                 + EnumChatFormatting.YELLOW + " (" + getLevelPercent(currentPet) + "%)";
 
-        String lvlString = EnumChatFormatting.AQUA + "" + Utils.shortNumberFormat(levelXp, 0) + "/" +
-                Utils.shortNumberFormat(currentPet.petLevel.currentLevelRequirement, 0)
+        String lvlString = EnumChatFormatting.AQUA + "" + Utils.shortNumberFormat(levelXp) + "/" +
+                Utils.shortNumberFormat(currentPet.petLevel.currentLevelRequirement)
                 + EnumChatFormatting.YELLOW + " (" + getLevelPercent(currentPet) + "%)";
 
         float xpGain;

--- a/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/util/Utils.java
@@ -255,15 +255,15 @@ public class Utils {
         return rainbowText.toString();
     }
 
-    private static char[] c = new char[]{'k', 'm', 'b', 't'};
-    public static String shortNumberFormat(double n, int iteration) {
-        double d = ((long) n / 100) / 10.0;
-        boolean isRound = (d * 10) %10 == 0;
-        return (d < 1000?
-                ((d > 99.9 || isRound || (!isRound && d > 9.99)?
-                        (int) d * 10 / 10 : d + ""
-                ) + "" + c[iteration])
-                : shortNumberFormat(d, iteration+1));
+    private static char[] c = new char[]{'k', 'M', 'B', 't', 'q', 'Q', 's', 'S'};
+    public static String shortNumberFormat(double n, int dp) {
+        int pow1k = (int) Math.floor(Math.log(n) / Math.log(1000));
+        if (pow1k == 0 || pow1k > 8) {return String.valueOf(n);}
+        double mantissa = n / (Math.pow(1000, pow1k));
+        return (String.format("%." + dp + "f", mantissa) + c[pow1k - 1]);
+    }
+    public static String shortNumberFormat(double n) {
+        return shortNumberFormat(n, 1);
     }
 
     public static String trimIgnoreColour(String str) {


### PR DESCRIPTION
This PR improves the shortNumberFormat() function to allow for the number of decimal places to be specified. This involved re-doing the way the function worked. Instead of using recursion, it now takes the log base 1000 of the number. It now also supports numbers up to 10²⁶.

By default, the function returns 1 dp like before, but I've changed it for damage indicators to show 2 dp instead. All the instances of the function have been replaced.