### PR TITLE
Run wiki renderer on a different thread

### DIFF
--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -743,7 +743,7 @@ public class NEUOverlay extends Gui {
                                 if(Mouse.getEventButton() == 0) {
                                     manager.showRecipe(item);
                                 } else if(Mouse.getEventButton() == 1) {
-                                    showInfo(item);
+                                    new Thread(() -> showInfo(item)).start();
                                 } else if(Mouse.getEventButton() == manager.keybindItemSelect.getKeyCode()+100  && NotEnoughUpdates.INSTANCE.config.toolbar.searchBar) {
                                     textField.setText("id:"+item.get("internalname").getAsString());
                                     updateSearch();

--- a/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/NEUOverlay.java
@@ -710,7 +710,7 @@ public class NEUOverlay extends Gui {
                             if(Mouse.getEventButton() == 0) {
                                 manager.showRecipe(item);
                             } else if(Mouse.getEventButton() == 1) {
-                                showInfo(item);
+                                new Thread(() -> showInfo(item)).start();
                             } else if(Mouse.getEventButton() == manager.keybindItemSelect.getKeyCode()+100 && NotEnoughUpdates.INSTANCE.config.toolbar.searchBar) {
                                 textField.setText("id:"+item.get("internalname").getAsString());
                                 updateSearch();

--- a/src/main/java/io/github/moulberry/notenoughupdates/infopanes/HTMLInfoPane.java
+++ b/src/main/java/io/github/moulberry/notenoughupdates/infopanes/HTMLInfoPane.java
@@ -94,6 +94,9 @@ public class HTMLInfoPane extends TextInfoPane {
      */
     public static HTMLInfoPane createFromWikiUrl(NEUOverlay overlay, NEUManager manager, String name,
                                                  String wikiUrl) {
+        // Display a loading pane before downloading the page
+        overlay.displayInformationPane(new TextInfoPane(overlay, manager, name, EnumChatFormatting.GRAY+"Downloading webpage (" + name + EnumChatFormatting.RESET+
+                EnumChatFormatting.GRAY+"), please wait..."));
         File f = manager.getWebFile(wikiUrl);
         if(f == null) {
             return new HTMLInfoPane(overlay, manager, "error", "error","Failed to load wiki url: "+ wikiUrl);


### PR DESCRIPTION
Runs the code to render a wiki page for an item on a different thread, so the game doesn't freeze while it's loading. I was unable to break it after a few minutes of testing, and the functionality is exactly the same as before. Let me know if there's something wrong with this solution, thanks.

edit: I added a "Downloading webpage" loading pane that appears immediately after clicking an item in the menu